### PR TITLE
refactor: make some variables private in struct

### DIFF
--- a/persist/memory.go
+++ b/persist/memory.go
@@ -10,7 +10,7 @@ import (
 
 // MemoryStore local memory cache store
 type MemoryStore struct {
-	Cache *ttlcache.Cache
+	cache *ttlcache.Cache
 }
 
 // NewMemoryStore allocate a local memory store with default expiration
@@ -18,27 +18,27 @@ func NewMemoryStore(defaultExpiration time.Duration) *MemoryStore {
 	cacheStore := ttlcache.NewCache()
 	_ = cacheStore.SetTTL(defaultExpiration)
 
-	// disable SkipTTLExtensionOnHit default
+	// disable SkipTTLExtensionOnHit by default
 	cacheStore.SkipTTLExtensionOnHit(true)
 
 	return &MemoryStore{
-		Cache: cacheStore,
+		cache: cacheStore,
 	}
 }
 
 // Set put key value pair to memory store, and expire after expireDuration
 func (c *MemoryStore) Set(key string, value interface{}, expireDuration time.Duration) error {
-	return c.Cache.SetWithTTL(key, value, expireDuration)
+	return c.cache.SetWithTTL(key, value, expireDuration)
 }
 
 // Delete remove key in memory store, do nothing if key doesn't exist
 func (c *MemoryStore) Delete(key string) error {
-	return c.Cache.Remove(key)
+	return c.cache.Remove(key)
 }
 
-// Get get key in memory store, if key doesn't exist, return ErrCacheMiss
+// Get key in memory store, if key doesn't exist, return ErrCacheMiss
 func (c *MemoryStore) Get(key string, value interface{}) error {
-	val, err := c.Cache.Get(key)
+	val, err := c.cache.Get(key)
 	if errors.Is(err, ttlcache.ErrNotFound) {
 		return ErrCacheMiss
 	}

--- a/persist/redis.go
+++ b/persist/redis.go
@@ -10,13 +10,13 @@ import (
 
 // RedisStore store http response in redis
 type RedisStore struct {
-	RedisClient *redis.Client
+	redisClient *redis.Client
 }
 
 // NewRedisStore create a redis memory store with redis client
 func NewRedisStore(redisClient *redis.Client) *RedisStore {
 	return &RedisStore{
-		RedisClient: redisClient,
+		redisClient: redisClient,
 	}
 }
 
@@ -28,19 +28,19 @@ func (store *RedisStore) Set(key string, value interface{}, expire time.Duration
 	}
 
 	ctx := context.TODO()
-	return store.RedisClient.Set(ctx, key, payload, expire).Err()
+	return store.redisClient.Set(ctx, key, payload, expire).Err()
 }
 
 // Delete remove key in redis, do nothing if key doesn't exist
 func (store *RedisStore) Delete(key string) error {
 	ctx := context.TODO()
-	return store.RedisClient.Del(ctx, key).Err()
+	return store.redisClient.Del(ctx, key).Err()
 }
 
 // Get retrieves an item from redis, if key doesn't exist, return ErrCacheMiss
 func (store *RedisStore) Get(key string, value interface{}) error {
 	ctx := context.TODO()
-	payload, err := store.RedisClient.Get(ctx, key).Bytes()
+	payload, err := store.redisClient.Get(ctx, key).Bytes()
 
 	if errors.Is(err, redis.Nil) {
 		return ErrCacheMiss


### PR DESCRIPTION
Some variable should be private in struct because you may replace it by other ones.