### PR TITLE
feat: add WithOnCacheMiss option

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -88,6 +88,7 @@ func cache(
 			if err != persist.ErrCacheMiss {
 				cfg.logger.Errorf("get cache error: %s, cache key: %s", err, cacheKey)
 			}
+			cfg.missCacheCallback(c)
 		}
 
 		// cache miss, then call the backend

--- a/option.go
+++ b/option.go
@@ -12,7 +12,8 @@ type Config struct {
 
 	getCacheStrategyByRequest GetCacheStrategyByRequest
 
-	hitCacheCallback OnHitCacheCallback
+	hitCacheCallback  OnHitCacheCallback
+	missCacheCallback OnMissCacheCallback
 
 	beforeReplyWithCacheCallback BeforeReplyWithCacheCallback
 
@@ -27,6 +28,7 @@ func newConfigByOpts(opts ...Option) *Config {
 	cfg := &Config{
 		logger:                       Discard{},
 		hitCacheCallback:             defaultHitCacheCallback,
+		missCacheCallback:            defaultMissCacheCallback,
 		beforeReplyWithCacheCallback: defaultBeforeReplyWithCacheCallback,
 		shareSingleFlightCallback:    defaultShareSingleFlightCallback,
 	}
@@ -82,6 +84,20 @@ func WithOnHitCache(cb OnHitCacheCallback) Option {
 	return func(c *Config) {
 		if cb != nil {
 			c.hitCacheCallback = cb
+		}
+	}
+}
+
+// OnMissCacheCallback define the callback when use cache
+type OnMissCacheCallback func(c *gin.Context)
+
+var defaultMissCacheCallback = func(c *gin.Context) {}
+
+// WithOnMissCache will be called when cache miss.
+func WithOnMissCache(cb OnMissCacheCallback) Option {
+	return func(c *Config) {
+		if cb != nil {
+			c.missCacheCallback = cb
 		}
 	}
 }


### PR DESCRIPTION
This is similar to WithOnCacheHit. It is also triggered on error (as this is technically a cache miss). This is useful if you want to keep metrics about hit and miss without having another middleware.